### PR TITLE
Massively increased the Min/Max distance & height caps. Swapped to Sliders instead of Drag Floats.

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -21,10 +21,11 @@ namespace DynamicCamera
         private const nint DISTANCE_OFFSET = 0x748;
         private const nint HEIGHT_OFFSET = 0x744;
 
-        private const float CAMERA_DISTANCE_MIN = -1500f;
-        private const float CAMERA_DISTANCE_MAX = 2000f;
-        private const float CAMERA_HEIGHT_MIN = -1125f;
-        private const float CAMERA_HEIGHT_MAX = 1950f;
+        private const float CAMERA_DISTANCE_MIN = -15000f;
+        private const float CAMERA_DISTANCE_MAX = 20000f;
+        private const float CAMERA_HEIGHT_MIN = -11250f;
+        private const float CAMERA_HEIGHT_MAX = 19500f;
+
 
         private readonly Stage[] nonCombatStages = StageConditionals.nonCombatStages;
         private readonly Dictionary<Stage, float> FOVRange = StageConditionals.FOVRanges;
@@ -190,8 +191,8 @@ namespace DynamicCamera
             {
                 ImGui.Text($"Base/Hub Camera Settings");
 
-                ImGui.DragFloat("Camera Distance", ref cameraBaseDistance, 1f, CAMERA_DISTANCE_MIN, CAMERA_DISTANCE_MAX);
-                ImGui.DragFloat("Camera Height", ref cameraBaseHeight, 1f, CAMERA_HEIGHT_MIN, CAMERA_HEIGHT_MAX);
+                ImGui.SliderFloat("Camera Distance", ref cameraBaseDistance, CAMERA_DISTANCE_MIN, CAMERA_DISTANCE_MAX, "%.0f", ImGuiSliderFlags.Logarithmic);
+                ImGui.SliderFloat("Camera Height", ref cameraBaseHeight, CAMERA_HEIGHT_MIN, CAMERA_HEIGHT_MAX, "%.0f", ImGuiSliderFlags.Logarithmic);
 
                 cameraSave.BaseCamera.CameraDistance = cameraBaseDistance;
                 cameraSave.BaseCamera.CameraHeight = cameraBaseHeight;
@@ -200,8 +201,8 @@ namespace DynamicCamera
             {
                 ImGui.Text($"Combat Camera Settings");
 
-                ImGui.DragFloat("Camera Distance", ref cameraCombatDistance, 1f, CAMERA_DISTANCE_MIN, CAMERA_DISTANCE_MAX);
-                ImGui.DragFloat("Camera Height", ref cameraCombatHeight, 1f, CAMERA_HEIGHT_MIN, CAMERA_HEIGHT_MAX);
+                ImGui.SliderFloat("Camera Distance", ref cameraCombatDistance, CAMERA_DISTANCE_MIN, CAMERA_DISTANCE_MAX, "%.0f", ImGuiSliderFlags.Logarithmic);
+                ImGui.SliderFloat("Camera Height", ref cameraCombatHeight, CAMERA_HEIGHT_MIN, CAMERA_HEIGHT_MAX, "%.0f", ImGuiSliderFlags.Logarithmic);
 
                 cameraSave.CombatCamera.CameraDistance = cameraCombatDistance;
                 cameraSave.CombatCamera.CameraHeight = cameraCombatHeight;


### PR DESCRIPTION
I made a few simple changes to the Plugin.cs to address a few community concerns.

**cloudztin** (Nexus Mods)
> Played without any other mods installed. I cannnot say it simply doesn't work. It is working, but too slow. I have to adjust the distance to -15000 to reach my goal. The value is limited to 1500 however.
> According to the gif uploaded when I set the distance to 15000 just seems the same effect as the value about 500 in the gif. And the log just seems normal. I have installed the loader and .NET 8.0, all in all, everything fine, except the scale, just like scolling with a microscope. :(

I have had the same user experience, so I increased the cap of the min/max camera values, and swapped the ImGui settings input to a logarithmic SliderFloat.


Developed, Built, and Tested on a Linux machine (NixOS, Proton GE 22, dot net sdk_8_0_3xx), works as intended.